### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24-compatible majors

### DIFF
--- a/.github/workflows/earnings.yml
+++ b/.github/workflows/earnings.yml
@@ -21,17 +21,17 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci
 
       - name: Restore earnings cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: data/earnings
           key: earnings-${{ github.run_id }}
@@ -51,11 +51,11 @@ jobs:
           SHOULD_GEN_ALL: ${{ vars.SHOULD_GEN_ALL }}
           CUSTOM_STOCKS: ${{ vars.CUSTOM_STOCKS }}
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/indices.yml
+++ b/.github/workflows/indices.yml
@@ -12,11 +12,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci


### PR DESCRIPTION
GitHub deprecated the Node.js 20 actions runtime. Every action we use shipped a new major built on Node.js 24, so this bumps them all in one go.

| Action | Before | After |
| --- | --- | --- |
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

Also bumps the build's Node runtime from 20 → 24 (current LTS since 2025-10-28); `package.json` keeps `engines.node >=20`.

## Test plan

- [ ] After merge, manually trigger `Update earnings calendar` and confirm the deprecation warning is gone and the deploy still succeeds.